### PR TITLE
Unit conversions are mapped backwards

### DIFF
--- a/furlong/furlong.py
+++ b/furlong/furlong.py
@@ -1,16 +1,29 @@
 class Furlong(object):
     conversion_table = {
             'inches'    : ('centimeters', 2.54),
+            'feet'      : ('inches', 12)
     }
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             self.unit = key
             self.value = value
 
+        self._init_forward_map()
+        self._init_backward_map()
+
+    def _init_forward_map(self):
         for base, conv in Furlong.conversion_table.items():
             func_name, conv_value = Furlong.conversion_table[base]
             func_name = "as" + func_name.title()
             setattr(self, func_name, self._make_convertor( conv_value ))
+
+    def _init_backward_map(self):
+        for func_name, base_block in Furlong.conversion_table.items():
+            base_name = base_block[0]
+            conv_value = 1 / base_block[1] #inverse
+            func_name = "as" + func_name.title()
+            setattr(self, func_name, self._make_convertor( conv_value ))
+
 
     def _make_convertor(self, conv_value):
         def _convertor():

--- a/tests/tests_fobject.py
+++ b/tests/tests_fobject.py
@@ -5,13 +5,25 @@ class TestSimpleConversionTests(unittest.TestCase):
     def test_fixed_conversion_test(self):
         self.assertEqual( f(inches=12).asCentimeters(), 30.48 )
 
+    def test_back_mapping_of_units(self):
+        self.assertEqual( f(centimeters=30.48).asInches(), 12 )
+
 
 class TestDyanmicFunctionNaming(unittest.TestCase):
-    def test_dyanmic_function_exists(self):
+    def setUp(self):
         test_conv = {
             'testbase'    : ('testconv', -1111),
         }
         f.conversion_table.update( test_conv )
+
+    def test_dyanmic_function_exists(self):
         self.assertIsInstance( f(testbase=1), f )
         self.assertTrue( callable( f(testbase=1).asTestconv ) )
         self.assertEqual( f(testbase=2).asTestconv(), -2222 )
+
+    def test_dyanamic_back_mapping(self):
+        self.assertIsInstance( f(testconv=1), f )
+        self.assertTrue( callable( f(testconv=1).asTestbase ) )
+        self.assertEqual( f(testconv=1).asTestbase(), (1/-1111) )
+
+


### PR DESCRIPTION
defining centimeters -> inches also means inches -> centimeters are defined

closes #2